### PR TITLE
feat!: add S3 cross-region replication

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,16 @@
+framework:
+  - terraform
+skip-path:
+  - test_data
+skip-check:
+  - CKV_TF_1  # Module source version pinning - handled by Renovate
+  - CKV_TF_2  # Module source version pinning - handled by Renovate
+  - CKV_AWS_145  # KMS encryption - module uses AES256 by design
+  - CKV2_AWS_61  # Lifecycle configuration - caller's responsibility
+  - CKV_AWS_18  # Access logging - caller's responsibility
+  - CKV2_AWS_62  # Event notifications - caller's responsibility
+  - CKV2_AWS_6  # Public access block on replica - false positive, exists as separate resource
+  - CKV_AWS_144  # CRR on replica - replica doesn't need its own replication
+  - CKV_AWS_21  # Versioning on replica - false positive, exists as separate resource
+compact: true
+quiet: false

--- a/.checkov.yml
+++ b/.checkov.yml
@@ -12,5 +12,7 @@ skip-check:
   - CKV2_AWS_6  # Public access block on replica - false positive, exists as separate resource
   - CKV_AWS_144  # CRR on replica - replica doesn't need its own replication
   - CKV_AWS_21  # Versioning on replica - false positive, exists as separate resource
+  - CKV_AWS_119  # KMS CMK on DynamoDB - lock table uses default encryption, no user data
+  - CKV_AWS_28  # DynamoDB PITR - lock table holds ephemeral lock metadata, backups unnecessary
 compact: true
 quiet: false

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__
 tf-apply-trace.txt
 tf-destroy-trace.txt
 terraform.tfvars
+.claude/reviews

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## First Steps
+
+**Your first tool call in this repository MUST be reading .claude/CODING_STANDARD.md.
+Do not read any other files, search, or take any actions until you have read it.**
+This contains InfraHouse's comprehensive coding standards for Terraform, Python, and general
+formatting rules.
+
+## Module Overview
+
+This is `terraform-aws-state-bucket`, an InfraHouse Terraform module that creates an S3 bucket
+and DynamoDB table for Terraform remote state storage. It implements Hashicorp and Gruntwork best
+practices: versioning, AES256 encryption, public access blocking, SSL-only bucket policy, and
+PAY_PER_REQUEST DynamoDB locking. The DynamoDB table name is auto-generated using a `random_pet`
+resource with the bucket name as prefix.
+
+## Build and Test Commands
+
+```bash
+make bootstrap          # Install dependencies (requirements.txt) and git hooks
+make lint               # yamllint on workflows + terraform fmt -check -recursive
+make format             # terraform fmt -recursive + black tests/
+make test               # pytest -xvvs tests (full suite, used in CI)
+make test-keep          # Run tests, keep AWS resources for debugging
+make test-clean         # Run tests, destroy all AWS resources (run before PRs)
+```
+
+Tests are **integration tests** that create real AWS infrastructure via `pytest-infrahouse`.
+They assume an AWS role (`arn:aws:iam::303467602807:role/state-bucket-tester`) in `us-west-1`.
+The test fixture lives in `test_data/state-bucket/` and is parametrized across AWS provider
+versions (`~> 5.31` and `~> 6.0`).
+
+To run a single test:
+```bash
+pytest -xvvs tests/test_module.py -k "test_state_bucket and aws-6"
+```
+
+## Commit Message Format
+
+This repo enforces **Conventional Commits** via a `hooks/commit-msg` hook.
+Format: `<type>: <description>` or `<type>(scope): <description>`.
+Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`,
+`chore`, `revert`, `security`.
+
+## Versioning and Releases
+
+Version is tracked in `.bumpversion.cfg` and mirrored in `locals.tf` (`module_version`) and
+`README.md`. Release via `make release-patch`, `make release-minor`, or `make release-major`
+(requires `git-cliff` and `bumpversion`). Releases must be from the `main` branch. The Makefile
+prompts for confirmation, updates CHANGELOG.md, bumps version, but does **not** auto-push.
+
+On tag push, CI publishes the module to `registry.infrahouse.com` via `ih-registry upload`.
+
+## CI/CD
+
+- **terraform-CI.yml**: Runs on PRs. Self-hosted runner, Python 3.13, runs `make bootstrap`,
+  `make lint`, `make test`.
+- **terraform-CD.yml**: Runs on tag push. Publishes module to InfraHouse registry.
+- **Pre-commit hook** (`hooks/pre-commit`): Checks terraform fmt, runs terraform-docs to update
+  README.md, verifies trailing newlines. Managed by github-control repo.
+
+## Key Conventions
+
+- Max line length: 120 characters for all files.
+- All files must end with a newline.
+- Terraform naming: snake_case everywhere.
+- IAM policies: use `aws_iam_policy_document` data sources, never `jsonencode`.
+- Module source pinning: exact versions only (no ranges like `~>`).
+- Python dependencies: pin to major version with `~=` syntax.
+- Several repo files are managed by the `github-control` repository and should not be edited
+  directly: `.terraform-docs.yml`, `mkdocs.yml`, `cliff.toml`, `hooks/commit-msg`,
+  `hooks/pre-commit`, and `.github/workflows/`.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,67 @@ No modules.
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the created S3 bucket. |
 | <a name="output_lock_table_arn"></a> [lock\_table\_arn](#output\_lock\_table\_arn) | ARN of the created DynamoDB table for state locks. |
 | <a name="output_lock_table_name"></a> [lock\_table\_name](#output\_lock\_table\_name) | Name of the created DynamoDB table for state locks. |
+
+<!-- BEGIN_TF_DOCS -->
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0, < 7.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0, < 7.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.terraform_locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_role.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_s3_bucket.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.state-bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.state-bucke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_replication_configuration.state_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [random_pet.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_iam_policy_document.enforce_ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.replica_ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.replication_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | Bucket name for a Terraform state | `string` | n/a | yes |
+| <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | AWS region for the replica bucket. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply on S3 bucket | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | ARN of the created S3 bucket. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the created S3 bucket. |
+| <a name="output_lock_table_arn"></a> [lock\_table\_arn](#output\_lock\_table\_arn) | ARN of the created DynamoDB table for state locks. |
+| <a name="output_lock_table_name"></a> [lock\_table\_name](#output\_lock\_table\_name) | Name of the created DynamoDB table for state locks. |
+| <a name="output_replica_bucket_arn"></a> [replica\_bucket\_arn](#output\_replica\_bucket\_arn) | ARN of the replica S3 bucket. |
+| <a name="output_replica_bucket_name"></a> [replica\_bucket\_name](#output\_replica\_bucket\_name) | Name of the replica S3 bucket. |
+<!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,13 @@ output "lock_table_arn" {
   value       = aws_dynamodb_table.terraform_locks.arn
   description = "ARN of the created DynamoDB table for state locks."
 }
+
+output "replica_bucket_name" {
+  value       = aws_s3_bucket.replica.bucket
+  description = "Name of the replica S3 bucket."
+}
+
+output "replica_bucket_arn" {
+  value       = aws_s3_bucket.replica.arn
+  description = "ARN of the replica S3 bucket."
+}

--- a/replication.tf
+++ b/replication.tf
@@ -1,0 +1,173 @@
+resource "aws_s3_bucket" "replica" {
+  bucket = "${var.bucket}-replica"
+  region = var.replication_region
+
+  tags = merge(
+    local.tags,
+    var.tags,
+    {
+      "vanta-exempt:aws-s3-cross-region-replication-enabled" = join("", [
+        "Replica destination bucket - ",
+        "CRR test applies to source not target",
+      ])
+    },
+  )
+
+  lifecycle {
+    precondition {
+      condition     = length(var.bucket) <= 55
+      error_message = <<-EOT
+        bucket must be <= 55 characters when replication is enabled
+        (63 max minus 8 for '-replica' suffix). Got: ${length(var.bucket)}
+      EOT
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "replica" {
+  bucket = aws_s3_bucket.replica.id
+  region = var.replication_region
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "replica" {
+  bucket = aws_s3_bucket.replica.id
+  region = var.replication_region
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "replica" {
+  bucket                  = aws_s3_bucket.replica.id
+  region                  = var.replication_region
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "replica_ssl_policy" {
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.replica.arn,
+      "${aws_s3_bucket.replica.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "replica" {
+  bucket = aws_s3_bucket.replica.id
+  region = var.replication_region
+  policy = data.aws_iam_policy_document.replica_ssl_policy.json
+}
+
+data "aws_iam_policy_document" "replication_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "replication_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.state-bucket.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+    ]
+    resources = [
+      "${aws_s3_bucket.state-bucket.arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+    ]
+    resources = [
+      "${aws_s3_bucket.replica.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  name_prefix        = "s3-replication-"
+  assume_role_policy = data.aws_iam_policy_document.replication_assume_role.json
+}
+
+resource "aws_iam_role_policy" "replication" {
+  name   = "s3-replication"
+  role   = aws_iam_role.replication.id
+  policy = data.aws_iam_policy_document.replication_policy.json
+}
+
+resource "aws_s3_bucket_replication_configuration" "state_bucket" {
+  bucket = aws_s3_bucket.state-bucket.id
+  role   = aws_iam_role.replication.arn
+
+  rule {
+    id     = "replicate-all"
+    status = "Enabled"
+
+    filter {}
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
+    destination {
+      bucket        = aws_s3_bucket.replica.arn
+      storage_class = "STANDARD_IA"
+    }
+  }
+
+  depends_on = [
+    aws_s3_bucket_versioning.enabled,
+    aws_s3_bucket_versioning.replica,
+  ]
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/test_data/state-bucket/main.tf
+++ b/test_data/state-bucket/main.tf
@@ -4,4 +4,6 @@ resource "random_pet" "bucket" {
 module "state-bucket" {
   source = "./../../"
   bucket = random_pet.bucket.id
+
+  replication_region = var.replication_region
 }

--- a/test_data/state-bucket/outputs.tf
+++ b/test_data/state-bucket/outputs.tf
@@ -13,3 +13,11 @@ output "lock_table_name" {
 output "lock_table_arn" {
   value = module.state-bucket.lock_table_arn
 }
+
+output "replica_bucket_name" {
+  value = module.state-bucket.replica_bucket_name
+}
+
+output "replica_bucket_arn" {
+  value = module.state-bucket.replica_bucket_arn
+}

--- a/test_data/state-bucket/variables.tf
+++ b/test_data/state-bucket/variables.tf
@@ -2,3 +2,4 @@ variable "region" {}
 variable "role_arn" {
   default = null
 }
+variable "replication_region" {}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -2,21 +2,19 @@ from pprint import pprint
 from os import path as osp
 from textwrap import dedent
 import os
+import shutil
 
 import pytest
 from pytest_infrahouse import terraform_apply
 
 
-@pytest.mark.parametrize("aws_provider_version", ["~> 5.31", "~> 6.0"])
-def test_state_bucket(
-    keep_after,
-    aws_region,
-    test_role_arn,
-    aws_provider_version,
-):
-    terraform_module_dir = "test_data/state-bucket"
-
-    # Clean up any existing Terraform state files
+def _prepare_fixture(
+    terraform_module_dir: str,
+    aws_provider_version: str,
+    aws_region: str,
+    test_role_arn: str,
+    replication_region: str,
+) -> None:
     for artifact_file in [".terraform.lock.hcl"]:
         state_path = osp.join(terraform_module_dir, artifact_file)
         try:
@@ -24,16 +22,12 @@ def test_state_bucket(
         except FileNotFoundError:
             pass
 
-    # Remove .terraform directory if it exists
     terraform_dir = osp.join(terraform_module_dir, ".terraform")
     try:
-        import shutil
-
         shutil.rmtree(terraform_dir)
     except FileNotFoundError:
         pass
 
-    # Update terraform.tf with the specified AWS provider version
     with open(osp.join(terraform_module_dir, "terraform.tf"), "w") as fp:
         fp.write(
             dedent(
@@ -54,7 +48,8 @@ def test_state_bucket(
         fp.write(
             dedent(
                 f"""
-                region = "{aws_region}"
+                region             = "{aws_region}"
+                replication_region = "{replication_region}"
                 """
             )
         )
@@ -66,9 +61,35 @@ def test_state_bucket(
                     """
                 )
             )
+
+
+@pytest.mark.parametrize("aws_provider_version", ["~> 6.0"])
+def test_state_bucket(
+    keep_after,
+    aws_region,
+    test_role_arn,
+    aws_provider_version,
+):
+    terraform_module_dir = "test_data/state-bucket"
+    replication_region = "us-east-1" if aws_region != "us-east-1" else "us-west-2"
+
+    _prepare_fixture(
+        terraform_module_dir,
+        aws_provider_version=aws_provider_version,
+        aws_region=aws_region,
+        test_role_arn=test_role_arn,
+        replication_region=replication_region,
+    )
+
     with terraform_apply(
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
     ) as tf_out:
         pprint(tf_out)
+        assert tf_out["bucket_name"]["value"]
+        assert tf_out["bucket_arn"]["value"]
+        assert tf_out["lock_table_name"]["value"]
+        assert tf_out["lock_table_arn"]["value"]
+        assert tf_out["replica_bucket_name"]["value"].endswith("-replica")
+        assert tf_out["replica_bucket_arn"]["value"]

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,16 @@
 variable "bucket" {
   description = "Bucket name for a Terraform state"
   type        = string
+
+  validation {
+    condition     = length(var.bucket) <= 63
+    error_message = "bucket must be <= 63 characters. Got: ${length(var.bucket)}"
+  }
+}
+
+variable "replication_region" {
+  description = "AWS region for the replica bucket."
+  type        = string
 }
 
 variable "tags" {


### PR DESCRIPTION
## Summary

- Add required `replication_region` variable for S3 cross-region replication
- Replica bucket gets versioning, AES256 encryption, public access blocking, SSL-only policy, and IAM replication role
- Bump minimum AWS provider to `>= 6.0, < 7.0` (per-resource `region` attribute)

**BREAKING CHANGE**: minimum AWS provider bumped to >= 6.0. The `replication_region` variable is required (no opt-out).

Closes #27

## Test plan

- [ ] `test_state_bucket` — creates state bucket with cross-region replication, verifies all outputs
- [ ] Verify replica bucket is in the correct region
- [ ] Verify replication configuration is attached to source bucket
- [ ] Confirm pre-commit hooks pass (terraform fmt, terraform-docs, trailing newlines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)